### PR TITLE
Fix: Add React 19 compatibility by externalizing jsx-runtime

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig((configEnv) => ({
       fileName: (format) => `react-smoke.${format}.js`,
     },
     rollupOptions: {
-      external: [...Object.keys(packageJson.peerDependencies)],
+      external: [...Object.keys(packageJson.peerDependencies), 'react/jsx-runtime', 'react/jsx-dev-runtime'],
       output: {
         globals: {
           react: "React",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 import EsLint from "vite-plugin-linter";
 import tsConfigPaths from "vite-tsconfig-paths";
+
 const { EsLinter, linterPlugin } = EsLint;
 import * as packageJson from "./package.json";
 
@@ -27,13 +28,18 @@ export default defineConfig((configEnv) => ({
       fileName: (format) => `react-smoke.${format}.js`,
     },
     rollupOptions: {
-      external: [...Object.keys(packageJson.peerDependencies), 'react/jsx-runtime', 'react/jsx-dev-runtime'],
+      external: [
+        ...Object.keys(packageJson.peerDependencies),
+        "react/jsx-runtime",
+        "react/jsx-dev-runtime",
+      ],
       output: {
         globals: {
           react: "React",
           "react-dom": "ReactDOM",
           three: "THREE",
           "@react-three/fiber": "ReactThreeFiber",
+          "react/jsx-runtime": "ReactJsxRuntime",
         },
       },
     },


### PR DESCRIPTION
## Summary
- Fixes React 19 compatibility by externalizing jsx-runtime modules in the build configuration
- Resolves the `SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED` error when using react-smoke with React 19
- Maintains backward compatibility with React 18

## Problem
React 19 introduces changes to how the jsx-runtime is handled. Libraries that bundle React internals can encounter runtime errors like:
```
Uncaught TypeError: can't access property 'ReactCurrentOwner', 
s.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED is undefined
```

## Solution
This PR adds `'react/jsx-runtime'` and `'react/jsx-dev-runtime'` to the external dependencies in the Rollup configuration. This prevents these modules from being bundled with the library, allowing React 19 to provide them at runtime.

## Test plan
- [x] Built library with the changes
- [x] Tested with React 19.1.0 in a production application
- [x] Verified smoke effects render correctly without console errors
- [x] Confirmed backward compatibility with React 18

🤖 Generated with [Claude Code](https://claude.ai/code)